### PR TITLE
[#17] DB 연결 및 테스트 코드 작성

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -6,6 +6,10 @@ dependencies {
     implementation project(':core')
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    testImplementation 'org.testcontainers:testcontainers'
+    testImplementation 'org.testcontainers:mysql'
+    testImplementation 'org.testcontainers:junit-jupiter'
 }
 
 test {

--- a/api/src/main/java/burgermap/advice/MemberExceptionAdvice.java
+++ b/api/src/main/java/burgermap/advice/MemberExceptionAdvice.java
@@ -1,0 +1,24 @@
+package burgermap.advice;
+
+import burgermap.exception.member.MemberNotExistException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@RestControllerAdvice
+@Slf4j
+public class MemberExceptionAdvice {
+    /**
+     * 예외 처리: 회원 식별 번호로 회원 조회 시 회원이 존재하지 않는 경우 404 NOT_FOUND 반환
+     * 예외 발생 지점: MemberService, StoreService
+     */
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(MemberNotExistException.class)
+    public Map<String, String> handleMemberNotExistException(MemberNotExistException e) {
+        return Map.of("message", e.getMessage());
+    }
+}

--- a/api/src/main/java/burgermap/controller/FoodController.java
+++ b/api/src/main/java/burgermap/controller/FoodController.java
@@ -56,7 +56,7 @@ public class FoodController {
             @SessionAttribute(name = SessionConstants.loginMember) Long memberId,
             @PathVariable Long storeId,
             @RequestBody FoodInfoRequestDto foodInfoRequestDto) {
-        Food food = cvtToFood(foodInfoRequestDto, storeId);
+        Food food = cvtToFood(foodInfoRequestDto);
         Food addedFood = foodService.addFood(food, storeId, memberId);
         return ResponseEntity.ok(cvtToFoodInfoDto(addedFood));
     }
@@ -75,9 +75,8 @@ public class FoodController {
         return ingredientInfoDto;
     }
 
-    public Food cvtToFood(FoodInfoRequestDto foodInfoRequestDto, Long storeId) {
+    public Food cvtToFood(FoodInfoRequestDto foodInfoRequestDto) {
         Food food = new Food();
-        food.setStoreId(storeId);
         food.setName(foodInfoRequestDto.getName());
         food.setPrice(foodInfoRequestDto.getPrice());
         food.setDescription(foodInfoRequestDto.getDescription());
@@ -90,7 +89,7 @@ public class FoodController {
     public FoodInfoDto cvtToFoodInfoDto(Food food) {
         FoodInfoDto foodInfoDto = new FoodInfoDto();
         foodInfoDto.setFoodId(food.getFoodId());
-        foodInfoDto.setStoreId(food.getStoreId());
+        foodInfoDto.setStoreId(food.getStore().getStoreId());
         foodInfoDto.setName(food.getName());
         foodInfoDto.setPrice(food.getPrice());
         foodInfoDto.setDescription(food.getDescription());

--- a/api/src/main/java/burgermap/controller/StoreController.java
+++ b/api/src/main/java/burgermap/controller/StoreController.java
@@ -41,9 +41,8 @@ public class StoreController {
     @PostMapping
     public ResponseEntity<StoreInfoDto> addStore(@SessionAttribute(name = SessionConstants.loginMember, required = false) Long memberId,
                                                  @RequestBody StoreRequestDto storeRequestDto) {
-        System.out.println("storeAddRequestDto = " + storeRequestDto);
-        Store store = cvtToStore(storeRequestDto, memberId);
-        storeService.addStore(store);
+        Store store = cvtToStore(storeRequestDto);
+        storeService.addStore(store, memberId);
         System.out.println("store = " + store);
         return ResponseEntity.ok(cvtToStoreInfoDto(store));
     }
@@ -89,7 +88,7 @@ public class StoreController {
     public ResponseEntity<StoreInfoDto> updateStore(@SessionAttribute(name = SessionConstants.loginMember, required = false) Long memberId,
                                                     @PathVariable Long storeId,
                                                     @RequestBody StoreRequestDto storeRequestDto) {
-        Store newStoreInfo = cvtToStore(storeRequestDto, memberId);
+        Store newStoreInfo = cvtToStore(storeRequestDto);
         Store newStore = storeService.updateStore(memberId, storeId, newStoreInfo);
         return ResponseEntity.ok(cvtToStoreInfoDto(newStore));
     }
@@ -105,7 +104,7 @@ public class StoreController {
         return ResponseEntity.ok(cvtToStoreInfoDto(store));
     }
 
-    public Store cvtToStore(Object storeDto, Long memberId) {
+    public Store cvtToStore(Object storeDto) {
         Store store = new Store();
 
         if (storeDto instanceof StoreRequestDto storeRequestDto) {
@@ -113,7 +112,7 @@ public class StoreController {
             store.setAddress(storeRequestDto.getAddress());
             store.setPhone(storeRequestDto.getPhone());
             store.setIntroduction(storeRequestDto.getIntroduction());
-            store.setMemberId(memberId);
+            // member 필드는 서비스 레이어에서 설정
         }
 
         return store;

--- a/api/src/main/java/burgermap/entity/Food.java
+++ b/api/src/main/java/burgermap/entity/Food.java
@@ -9,6 +9,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -25,7 +26,8 @@ public class Food {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long foodId;
-    private Long storeId;
+    @ManyToOne
+    private Store store;
     private String name;
     private Integer price;
     private String description;

--- a/api/src/main/java/burgermap/entity/Member.java
+++ b/api/src/main/java/burgermap/entity/Member.java
@@ -1,6 +1,10 @@
 package burgermap.entity;
 
 import burgermap.enums.MemberType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +16,10 @@ import lombok.ToString;
 @ToString
 @NoArgsConstructor  // ObjectMapper 적용 목적
 @AllArgsConstructor  // 단위 테스트시 더미 데이터 생성 목적
+@Entity
 public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long memberId;
     private MemberType memberType;
     private String loginId;

--- a/api/src/main/java/burgermap/entity/Store.java
+++ b/api/src/main/java/burgermap/entity/Store.java
@@ -13,7 +13,8 @@ import lombok.ToString;
 @AllArgsConstructor
 public class Store {
     private Long storeId;  // id
-    private Long memberId;
+//    private Long memberId;
+    private Member member;
     private String name;
     private String address;
     private String phone;

--- a/api/src/main/java/burgermap/entity/Store.java
+++ b/api/src/main/java/burgermap/entity/Store.java
@@ -1,5 +1,10 @@
 package burgermap.entity;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,9 +16,12 @@ import lombok.ToString;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
+@Entity
 public class Store {
-    private Long storeId;  // id
-//    private Long memberId;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long storeId;
+    @ManyToOne
     private Member member;
     private String name;
     private String address;

--- a/api/src/main/java/burgermap/exception/member/MemberNotExistException.java
+++ b/api/src/main/java/burgermap/exception/member/MemberNotExistException.java
@@ -1,0 +1,7 @@
+package burgermap.exception.member;
+
+public class MemberNotExistException extends RuntimeException {
+    public MemberNotExistException(Long member) {
+        super("Member with member ID %d does not exist.".formatted(member));
+    }
+}

--- a/api/src/main/java/burgermap/repository/HashMapFoodRepository.java
+++ b/api/src/main/java/burgermap/repository/HashMapFoodRepository.java
@@ -23,7 +23,7 @@ public class HashMapFoodRepository implements FoodRepository{
     @Override
     public List<Food> findByStoreId(Long storeId) {
         return repository.values().stream()
-                .filter(food -> food.getStoreId().equals(storeId))
+                .filter(food -> food.getStore().getStoreId().equals(storeId))
                 .toList();
     }
 }

--- a/api/src/main/java/burgermap/repository/HashMapMemberRepository.java
+++ b/api/src/main/java/burgermap/repository/HashMapMemberRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-@Repository
+//@Repository
 public class HashMapMemberRepository implements MemberRepository{
 
     private final Map<Long, Member> repository = new ConcurrentHashMap<>();

--- a/api/src/main/java/burgermap/repository/HashMapMemberRepository.java
+++ b/api/src/main/java/burgermap/repository/HashMapMemberRepository.java
@@ -48,36 +48,6 @@ public class HashMapMemberRepository implements MemberRepository{
     }
 
     @Override
-    public Optional<Member> updatePassword(Long memberId, String newPassword) {
-        Member member = repository.get(memberId);
-        if (member == null) {
-            return Optional.empty();
-        }
-        member.setPassword(newPassword);
-        return Optional.of(member);
-    }
-
-    @Override
-    public Optional<Member> updateEmail(Long memberId, String newEmail) {
-        Member member = repository.get(memberId);
-        if (member == null) {
-            return Optional.empty();
-        }
-        member.setEmail(newEmail);
-        return Optional.of(member);
-    }
-
-    @Override
-    public Optional<Member> updateNickname(Long memberId, String newNickname) {
-        Member member = repository.get(memberId);
-        if (member == null) {
-            return Optional.empty();
-        }
-        member.setNickname(newNickname);
-        return Optional.of(member);
-    }
-
-    @Override
     public Optional<Member> deleteByMemberId(Long memberId) {
         return Optional.ofNullable(repository.remove(memberId));
     }

--- a/api/src/main/java/burgermap/repository/HashMapStoreRepository.java
+++ b/api/src/main/java/burgermap/repository/HashMapStoreRepository.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
-@Repository
+//@Repository
 public class HashMapStoreRepository implements StoreRepository{
 
     private final Map<Long, Store> repository = new ConcurrentHashMap<>();

--- a/api/src/main/java/burgermap/repository/HashMapStoreRepository.java
+++ b/api/src/main/java/burgermap/repository/HashMapStoreRepository.java
@@ -37,18 +37,6 @@ public class HashMapStoreRepository implements StoreRepository{
     }
 
     @Override
-    public Optional<Store> updateStore(Long storeId, Store newStore) {
-        Store oldStore = repository.get(storeId);
-        if (oldStore == null) {
-            return Optional.empty();
-        }
-
-        newStore.setStoreId(storeId);
-        repository.put(storeId, newStore);
-        return Optional.of(newStore);
-    }
-
-    @Override
     public Optional<Store> deleteByStoreId(Long storeId) {
         Store store = repository.remove(storeId);
         return Optional.ofNullable(store);

--- a/api/src/main/java/burgermap/repository/HashMapStoreRepository.java
+++ b/api/src/main/java/burgermap/repository/HashMapStoreRepository.java
@@ -31,7 +31,7 @@ public class HashMapStoreRepository implements StoreRepository{
     @Override
     public List<Store> findByMemberId(Long memberId) {
         List<Store> stores = repository.values().stream()
-                .filter(store -> store.getMemberId().equals(memberId))
+                .filter(store -> store.getMember().getMemberId().equals(memberId))
                 .toList();
         return stores;
     }

--- a/api/src/main/java/burgermap/repository/MemberRepository.java
+++ b/api/src/main/java/burgermap/repository/MemberRepository.java
@@ -10,8 +10,5 @@ public interface MemberRepository {
     public Optional<Member> findByLoginId(String loginId);
     public Optional<Member> findByEmail(String email);
     public Optional<Member> findByNickname(String nickname);
-    public Optional<Member> updatePassword(Long memberId, String newPassword);
-    public Optional<Member> updateEmail(Long memberId, String newEmail);
-    public Optional<Member> updateNickname(Long memberId, String newNickname);
     public Optional<Member> deleteByMemberId(Long memberId);
 }

--- a/api/src/main/java/burgermap/repository/MySqlMemberRepository.java
+++ b/api/src/main/java/burgermap/repository/MySqlMemberRepository.java
@@ -39,27 +39,6 @@ public class MySqlMemberRepository implements MemberRepository {
     }
 
     @Override
-    public Optional<Member> updatePassword(Long memberId, String newPassword) {
-        Member member = repository.findById(memberId).orElseThrow();
-        member.setPassword(newPassword);
-        return Optional.of(member);
-    }
-
-    @Override
-    public Optional<Member> updateEmail(Long memberId, String newEmail) {
-        Member member = repository.findById(memberId).orElseThrow();
-        member.setEmail(newEmail);
-        return Optional.of(member);
-    }
-
-    @Override
-    public Optional<Member> updateNickname(Long memberId, String newNickname) {
-        Member member = repository.findById(memberId).orElseThrow();
-        member.setNickname(newNickname);
-        return Optional.of(member);
-    }
-
-    @Override
     public Optional<Member> deleteByMemberId(Long memberId) {
         Member member = repository.findById(memberId).orElseThrow();
         repository.deleteById(memberId);

--- a/api/src/main/java/burgermap/repository/MySqlMemberRepository.java
+++ b/api/src/main/java/burgermap/repository/MySqlMemberRepository.java
@@ -1,0 +1,68 @@
+package burgermap.repository;
+
+import burgermap.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class MySqlMemberRepository implements MemberRepository {
+
+    private final SpringDataJpaMemberRepository repository;
+
+    @Override
+    public Member save(Member member) {
+        repository.save(member);
+        return member;
+    }
+
+    @Override
+    public Optional<Member> findByMemberId(Long memberId) {
+        return repository.findById(memberId);
+    }
+
+    @Override
+    public Optional<Member> findByLoginId(String loginId) {
+        return repository.findByLoginId(loginId);
+    }
+
+    @Override
+    public Optional<Member> findByEmail(String email) {
+        return repository.findByEmail(email);
+    }
+
+    @Override
+    public Optional<Member> findByNickname(String nickname) {
+        return repository.findByNickname(nickname);
+    }
+
+    @Override
+    public Optional<Member> updatePassword(Long memberId, String newPassword) {
+        Member member = repository.findById(memberId).orElseThrow();
+        member.setPassword(newPassword);
+        return Optional.of(member);
+    }
+
+    @Override
+    public Optional<Member> updateEmail(Long memberId, String newEmail) {
+        Member member = repository.findById(memberId).orElseThrow();
+        member.setEmail(newEmail);
+        return Optional.of(member);
+    }
+
+    @Override
+    public Optional<Member> updateNickname(Long memberId, String newNickname) {
+        Member member = repository.findById(memberId).orElseThrow();
+        member.setNickname(newNickname);
+        return Optional.of(member);
+    }
+
+    @Override
+    public Optional<Member> deleteByMemberId(Long memberId) {
+        Member member = repository.findById(memberId).orElseThrow();
+        repository.deleteById(memberId);
+        return Optional.of(member);
+    }
+}

--- a/api/src/main/java/burgermap/repository/MySqlMemberRepository.java
+++ b/api/src/main/java/burgermap/repository/MySqlMemberRepository.java
@@ -40,8 +40,8 @@ public class MySqlMemberRepository implements MemberRepository {
 
     @Override
     public Optional<Member> deleteByMemberId(Long memberId) {
-        Member member = repository.findById(memberId).orElseThrow();
+        Optional<Member> member = repository.findById(memberId);
         repository.deleteById(memberId);
-        return Optional.of(member);
+        return member;
     }
 }

--- a/api/src/main/java/burgermap/repository/MySqlStoreRepository.java
+++ b/api/src/main/java/burgermap/repository/MySqlStoreRepository.java
@@ -30,13 +30,6 @@ public class MySqlStoreRepository implements StoreRepository {
     }
 
     @Override
-    public Optional<Store> updateStore(Long storeId, Store newStore) {
-        newStore.setStoreId(storeId);
-        repository.save(newStore);
-        return Optional.of(newStore);
-    }
-
-    @Override
     public Optional<Store> deleteByStoreId(Long storeId) {
         Store store = repository.findById(storeId).get();
         repository.delete(store);

--- a/api/src/main/java/burgermap/repository/MySqlStoreRepository.java
+++ b/api/src/main/java/burgermap/repository/MySqlStoreRepository.java
@@ -31,8 +31,8 @@ public class MySqlStoreRepository implements StoreRepository {
 
     @Override
     public Optional<Store> deleteByStoreId(Long storeId) {
-        Store store = repository.findById(storeId).get();
-        repository.delete(store);
-        return Optional.of(store);
+        Optional<Store> store = repository.findById(storeId);
+        repository.deleteById(storeId);
+        return store;
     }
 }

--- a/api/src/main/java/burgermap/repository/MySqlStoreRepository.java
+++ b/api/src/main/java/burgermap/repository/MySqlStoreRepository.java
@@ -1,0 +1,45 @@
+package burgermap.repository;
+
+import burgermap.entity.Store;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class MySqlStoreRepository implements StoreRepository {
+
+    private final SpringDataJpaStoreRepository repository;
+
+    @Override
+    public Store save(Store store) {
+        repository.save(store);
+        return store;
+    }
+
+    @Override
+    public Optional<Store> findByStoreId(Long storeId) {
+        return repository.findById(storeId);
+    }
+
+    @Override
+    public List<Store> findByMemberId(Long memberId) {
+        return repository.findByMemberId(memberId);
+    }
+
+    @Override
+    public Optional<Store> updateStore(Long storeId, Store newStore) {
+        newStore.setStoreId(storeId);
+        repository.save(newStore);
+        return Optional.of(newStore);
+    }
+
+    @Override
+    public Optional<Store> deleteByStoreId(Long storeId) {
+        Store store = repository.findById(storeId).get();
+        repository.delete(store);
+        return Optional.of(store);
+    }
+}

--- a/api/src/main/java/burgermap/repository/SpringDataJpaMemberRepository.java
+++ b/api/src/main/java/burgermap/repository/SpringDataJpaMemberRepository.java
@@ -1,0 +1,15 @@
+package burgermap.repository;
+
+import burgermap.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SpringDataJpaMemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByLoginId(String loginId);
+
+    Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByNickname(String nickname);
+}

--- a/api/src/main/java/burgermap/repository/SpringDataJpaStoreRepository.java
+++ b/api/src/main/java/burgermap/repository/SpringDataJpaStoreRepository.java
@@ -1,0 +1,14 @@
+package burgermap.repository;
+
+import burgermap.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface SpringDataJpaStoreRepository extends JpaRepository<Store, Long> {
+
+    @Query("select s from Store s where s.member.memberId = :memberId")
+    List<Store> findByMemberId(@Param("memberId") Long memberId);
+}

--- a/api/src/main/java/burgermap/repository/StoreRepository.java
+++ b/api/src/main/java/burgermap/repository/StoreRepository.java
@@ -9,6 +9,5 @@ public interface StoreRepository {
     public Store save(Store store);
     public Optional<Store> findByStoreId(Long storeId);
     public List<Store> findByMemberId(Long memberId);
-    public Optional<Store> updateStore(Long storeId, Store newStore);
     public Optional<Store> deleteByStoreId(Long storeId);
 }

--- a/api/src/main/java/burgermap/service/FoodService.java
+++ b/api/src/main/java/burgermap/service/FoodService.java
@@ -54,6 +54,8 @@ public class FoodService {
         Store store = storeService.checkStoreExistence(storeId);
         storeService.checkStoreBelongTo(store, memberId);
 
+        food.setStore(store);
+
         return foodRepository.save(food);
     }
 

--- a/api/src/main/java/burgermap/service/FoodService.java
+++ b/api/src/main/java/burgermap/service/FoodService.java
@@ -22,7 +22,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Service
@@ -60,22 +62,23 @@ public class FoodService {
     }
 
     public List<Ingredient> ingredientIdsToIngredients(List<Long> ingredientIds) {
-        List<Optional<Ingredient>> ingredientList = ingredientIds.stream()
-                .map(ingredientRepository::findByIngredientId)
-                .toList();
+        // ingredientId, Optional<Ingredient> 맵으로 변환
+        Map<Long, Optional<Ingredient>> ingredientMap = ingredientIds.stream()
+                .collect(Collectors.toMap(ingredientId -> ingredientId, ingredientRepository::findByIngredientId));
 
-        List<String> notExistIngredientIds = Stream.iterate(0, i -> i + 1)
-                .limit(ingredientIds.size())
-                .filter(i -> ingredientList.get(i).isEmpty())
-                .map(i -> String.valueOf(ingredientIds.get(i)))
-                .toList();
+        // value가 empty인 ingredientId 수집
+        List<Long> notExistIngredientIdsList = ingredientMap.entrySet().stream()
+                .filter(entry -> entry.getValue().isEmpty())
+                .map(Map.Entry::getKey).toList();
 
-        if (!notExistIngredientIds.isEmpty()) {
-            String notExistIngredientIdsString = String.join(", ", notExistIngredientIds);
-            throw new FoodAttributeNotExistException("Ingredients Id %s does not exist".formatted(notExistIngredientIdsString));
+        if (!notExistIngredientIdsList.isEmpty()) {
+            String notExistIngredientIds = notExistIngredientIdsList.stream()
+                    .map(String::valueOf)
+                    .collect(Collectors.joining(", "));
+            log.debug("Ingredients Id {} does not exist", notExistIngredientIds);
+            throw new FoodAttributeNotExistException("Ingredients Id %s does not exist".formatted(notExistIngredientIds));
         }
-
-        return ingredientList.stream().map(Optional::get).toList();
+        return ingredientMap.values().stream().map(Optional::get).toList();
     }
 
     public MenuCategory menuCategoryIdToMenuCategory(Long menuCategoryId) {

--- a/api/src/main/java/burgermap/service/MemberService.java
+++ b/api/src/main/java/burgermap/service/MemberService.java
@@ -7,11 +7,13 @@ import burgermap.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 @Slf4j
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class MemberService {
 

--- a/api/src/main/java/burgermap/service/MemberService.java
+++ b/api/src/main/java/burgermap/service/MemberService.java
@@ -66,21 +66,25 @@ public class MemberService {
     }
 
     public Member changePassword(Long memberId, String newPassword) {
-        Optional<Member> member = repository.updatePassword(memberId, newPassword);
-        log.debug("member password changed: {}", member.get());
-        return member.get();
+        // 로그인이 필요하므로 회원 조회 결과가 존재
+        Member member = repository.findByMemberId(memberId).get();
+        member.setPassword(newPassword);
+        log.debug("member password changed: {}", member);
+        return member;
     }
 
     public Member changeEmail(Long memberId, String newEmail) {
-        Optional<Member> member = repository.updateEmail(memberId, newEmail);
-        log.debug("member email changed: {}", member.get());
-        return member.get();
+        Member member = repository.findByMemberId(memberId).get();
+        member.setEmail(newEmail);
+        log.debug("member email changed: {}", member);
+        return member;
     }
 
     public Member changeNickname(Long memberId, String newNickname) {
-        Optional<Member> member = repository.updateNickname(memberId, newNickname);
-        log.debug("member nickname changed: {}", member.get());
-        return member.get();
+        Member member = repository.findByMemberId(memberId).get();
+        member.setNickname(newNickname);
+        log.debug("member nickname changed: {}", member);
+        return member;
     }
 
     public Member deleteMember(Long memberId) {

--- a/api/src/main/java/burgermap/service/MemberService.java
+++ b/api/src/main/java/burgermap/service/MemberService.java
@@ -2,6 +2,7 @@ package burgermap.service;
 
 import burgermap.entity.Member;
 import burgermap.enums.MemberType;
+import burgermap.exception.member.MemberNotExistException;
 import burgermap.exception.store.NotOwnerMemberException;
 import burgermap.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -50,54 +51,64 @@ public class MemberService {
 
     public Member login(String loginId, String password) {
         Optional<Member> member = repository.findByLoginId(loginId);
-        log.debug("login member : {}", member.orElse(null));
         // 로그인 실패: loginId를 가진 회원이 존재하지 않는 경우, 회원은 존재하되 pw가 다른 경우
-        if (member.isEmpty() || !member.get().getPassword().equals(password)) {
-            log.debug("login failed");
-            return null;
+        if (member.isPresent()) {
+            log.debug("login member : {}", member.get());
+            if (member.get().getPassword().equals(password)) {
+                return member.get();
+            } else {
+                log.debug("login fail: incorrect password");
+                return null;
+            }
         }
-        return member.get();
+        log.debug("login fail: member not found (loginId: {})", loginId);
+        return null;
     }
 
     public Member getMyInfo(Long memberId) {
-        Member member = repository.findByMemberId(memberId).get();
+        Member member = repository.findByMemberId(memberId)
+                .orElseThrow(() -> new MemberNotExistException(memberId));
         log.debug("member info: {}", member);
         return member;
     }
 
     public Member changePassword(Long memberId, String newPassword) {
-        // 로그인이 필요하므로 회원 조회 결과가 존재
-        Member member = repository.findByMemberId(memberId).get();
+        Member member = repository.findByMemberId(memberId)
+                .orElseThrow(() -> new MemberNotExistException(memberId));
         member.setPassword(newPassword);
         log.debug("member password changed: {}", member);
         return member;
     }
 
     public Member changeEmail(Long memberId, String newEmail) {
-        Member member = repository.findByMemberId(memberId).get();
+        Member member = repository.findByMemberId(memberId)
+                .orElseThrow(() -> new MemberNotExistException(memberId));
         member.setEmail(newEmail);
         log.debug("member email changed: {}", member);
         return member;
     }
 
     public Member changeNickname(Long memberId, String newNickname) {
-        Member member = repository.findByMemberId(memberId).get();
+        Member member = repository.findByMemberId(memberId)
+                .orElseThrow(() -> new MemberNotExistException(memberId));
         member.setNickname(newNickname);
         log.debug("member nickname changed: {}", member);
         return member;
     }
 
     public Member deleteMember(Long memberId) {
-        Optional<Member> member = repository.deleteByMemberId(memberId);
-        log.debug("member deleted: {}", member.get());
-        return member.get();
+        Member member = repository.deleteByMemberId(memberId)
+                .orElseThrow(() -> new MemberNotExistException(memberId));;
+        log.debug("member deleted: {}", member);
+        return member;
     }
 
     /**
      * memberId에 해당하는 회원이 OWNER가 아니면 NotOwnerMemberException을 발생시킴
      */
     public void isMemberTypeOwner(Long memberId) {
-        Member member = repository.findByMemberId(memberId).get();
+        Member member = repository.findByMemberId(memberId)
+                .orElseThrow(() -> new MemberNotExistException(memberId));
         if (member.getMemberType() != MemberType.OWNER) {
             throw new NotOwnerMemberException("member type is not OWNER.");
         }

--- a/api/src/main/java/burgermap/service/StoreService.java
+++ b/api/src/main/java/burgermap/service/StoreService.java
@@ -8,12 +8,14 @@ import burgermap.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 
 @Slf4j
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class StoreService {
     private final MemberService memberService;

--- a/api/src/main/java/burgermap/service/StoreService.java
+++ b/api/src/main/java/burgermap/service/StoreService.java
@@ -46,11 +46,14 @@ public class StoreService {
 
     public Store updateStore(Long requestMemberId, Long storeId, Store newStoreInfo) {
         memberService.isMemberTypeOwner(requestMemberId);
-        Store oldStore = checkStoreExistence(storeId);
-        checkStoreBelongTo(oldStore, requestMemberId);
-        newStoreInfo.setMember(memberRepository.findByMemberId(requestMemberId).orElseThrow());
-        Optional<Store> newStore = storeRepository.updateStore(storeId, newStoreInfo);
-        return newStore.orElse(null);
+        Store store = checkStoreExistence(storeId);
+        checkStoreBelongTo(store, requestMemberId);
+
+        store.setName(newStoreInfo.getName());
+        store.setAddress(newStoreInfo.getAddress());
+        store.setPhone(newStoreInfo.getPhone());
+        store.setIntroduction(newStoreInfo.getIntroduction());
+        return store;
     }
 
     public Store deleteStore(Long requestMemberId, Long storeId) {

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -12,4 +12,4 @@ spring.jpa.properties.hibernate.hbm2ddl.import_files=init.sql
 
 # JPA log
 logging.level.org.hibernate.SQL=DEBUG
-logging.level.org.hibernate.orm.dbc.bind=TRACE
+logging.level.org.hibernate.orm.jdbc.bind=TRACE

--- a/api/src/test/java/burgermap/repository/MySqlIngredientRepositoryTest.java
+++ b/api/src/test/java/burgermap/repository/MySqlIngredientRepositoryTest.java
@@ -62,4 +62,15 @@ class MySqlIngredientRepositoryTest extends TestcontainersTest {
 
         assertThat(ingredient).hasValueSatisfying(i -> assertThat(i.getName()).isEqualTo(ingredientName));
     }
+
+    @Test
+    @DisplayName("존재하지 않는 재료 번호로 재료 조회")
+    void findByUnregisteredIngredientId() {
+        // 존재하지 않는 재료 번호(-1L, Long 최댓값)로 조회, 결과: Optional.empty()
+        Optional<Ingredient> ingredientNegativeId = repository.findByIngredientId(-1L);
+        Optional<Ingredient> ingredientUnregisteredId = repository.findByIngredientId(Long.MAX_VALUE);
+
+        assertThat(ingredientNegativeId).isEmpty();
+        assertThat(ingredientUnregisteredId).isEmpty();
+    }
 }

--- a/api/src/test/java/burgermap/repository/MySqlIngredientRepositoryTest.java
+++ b/api/src/test/java/burgermap/repository/MySqlIngredientRepositoryTest.java
@@ -1,0 +1,65 @@
+package burgermap.repository;
+
+import burgermap.entity.Ingredient;
+import jakarta.persistence.EntityManager;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+class MySqlIngredientRepositoryTest extends TestcontainersTest {
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private IngredientRepository repository;
+
+    private final String[] ingredientNames = new String[] {
+        "소고기패티", "체다치즈", "브리오슈번", "양상추", "토마토", "칠리소스", "칠리비프", "새우패티", "해쉬브라운", "베이컨"
+    };
+
+    @BeforeEach
+    void initIngredientsData() {
+        // 테스트를 위한 재료 데이터 등록
+        // 테스트 케이스마다 Id 자동 생성 시작값 초기화
+        em.createNativeQuery("alter table ingredient AUTO_INCREMENT = 1").executeUpdate();
+        for (String ingredientName : ingredientNames) {
+            Ingredient ingredient = new Ingredient();
+            ingredient.setName(ingredientName);
+            em.persist(ingredient);
+            System.out.println(ingredient.getIngredientId());
+        }
+    }
+
+    @Test
+    @DisplayName("등록된 모든 재료 조회")
+    void findAll() {
+        // 등록된 모든 재료 조회, 조회된 재료 수와 재료명 검증
+        List<Ingredient> allIngredients = repository.findAll();
+
+        assertThat(allIngredients).hasSize(ingredientNames.length);
+        assertThat(allIngredients).extracting("name").contains(ingredientNames);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {1L, 5L, 10L})
+    @DisplayName("재료 번호로 재료 조회")
+    void findByIngredientId(long ingredientId) {
+        // 재료 번호로 조회, 조회된 재료의 재료명 검증
+        Optional<Ingredient> ingredient = repository.findByIngredientId(ingredientId);
+        String ingredientName = ingredientNames[(int) ingredientId - 1];
+
+        assertThat(ingredient).hasValueSatisfying(i -> assertThat(i.getName()).isEqualTo(ingredientName));
+    }
+}

--- a/api/src/test/java/burgermap/repository/MySqlMemberRepositoryTest.java
+++ b/api/src/test/java/burgermap/repository/MySqlMemberRepositoryTest.java
@@ -123,69 +123,6 @@ class MySqlMemberRepositoryTest extends TestcontainersTest{
     }
 
     @Test
-    @DisplayName("회원 비밀번호 변경")
-    void updatePassword() {
-        // 회원 추가 후 비밀번호 변경, 조회된 회원 정보에 비밀번호 변경이 반영되었는지 검증
-        Member newMember = new Member();
-        newMember.setLoginId("testId");
-        newMember.setPassword("oldPassword");
-        newMember.setEmail("testEmail@gmail.com");
-        newMember.setNickname("testNickname");
-        newMember.setMemberType(MemberType.OWNER);
-        memberRepository.save(newMember);
-
-        String newPassword = "newPassword";
-        memberRepository.updatePassword(newMember.getMemberId(), newPassword);
-
-        Optional<Member> updatedMember = memberRepository.findByMemberId(newMember.getMemberId());
-        assertThat(updatedMember).hasValueSatisfying(member -> {
-            assertThat(member.getPassword()).isEqualTo(newPassword);
-        });
-    }
-
-    @Test
-    @DisplayName("회원 이메일 변경")
-    void updateEmail() {
-        // 회원 추가 후 이메일 변경, 조회된 회원 정보에 이메일 변경이 반영되었는지 검증
-        Member newMember = new Member();
-        newMember.setLoginId("testId");
-        newMember.setPassword("testPassword");
-        newMember.setEmail("oldEmail@gmail.com");
-        newMember.setNickname("testNickname");
-        newMember.setMemberType(MemberType.OWNER);
-        memberRepository.save(newMember);
-
-        String newEmail = "newEmail@gmail.com";
-        memberRepository.updateEmail(newMember.getMemberId(), newEmail);
-
-        Optional<Member> updatedMember = memberRepository.findByMemberId(newMember.getMemberId());
-        assertThat(updatedMember).hasValueSatisfying(member -> {
-            assertThat(member.getEmail()).isEqualTo(newEmail);
-        });
-    }
-
-    @Test
-    @DisplayName("회원 닉네임 변경")
-    void updateNickname() {
-        // 회원 추가 후 닉네임 변경, 조회된 회원 정보에 닉네임 변경이 반영되었는지 검증
-        Member newMember = new Member();
-        newMember.setLoginId("testId");
-        newMember.setPassword("testPassword");
-        newMember.setEmail("testEmail@gmail.com");
-        newMember.setNickname("oldNickname");
-        newMember.setMemberType(MemberType.OWNER);
-        memberRepository.save(newMember);
-
-        String newNickname = "newNickname";
-        memberRepository.updateNickname(newMember.getMemberId(), newNickname);
-
-        Optional<Member> updatedMember = memberRepository.findByMemberId(newMember.getMemberId());
-        assertThat(updatedMember).hasValueSatisfying(member -> {
-            assertThat(member.getNickname()).isEqualTo(newNickname);
-        });
-    }
-
-    @Test
     @DisplayName("회원 삭제")
     void deleteByMemberId() {
         // 회원 추가 후 삭제, 삭제된 회원을 조회시 Optional.empty() 반환 검증

--- a/api/src/test/java/burgermap/repository/MySqlMemberRepositoryTest.java
+++ b/api/src/test/java/burgermap/repository/MySqlMemberRepositoryTest.java
@@ -1,0 +1,205 @@
+package burgermap.repository;
+
+import burgermap.entity.Member;
+import burgermap.enums.MemberType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+class MySqlMemberRepositoryTest extends TestcontainersTest{
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("회원 추가 및 회원 번호 조회")
+    void saveAndFindByMemberId() {
+        // 회원 추가 후 조회, 저장한 정보와 조회된 정보가 같은지 검증
+        Member newMember = new Member();
+        newMember.setLoginId("testId");
+        newMember.setPassword("testPassword");
+        newMember.setEmail("testEmail@gmail.com");
+        newMember.setNickname("testNickname");
+        newMember.setMemberType(MemberType.OWNER);
+
+        memberRepository.save(newMember);
+        Optional<Member> savedMember = memberRepository.findByMemberId(newMember.getMemberId());
+
+        // hasValueSatisfying:
+        // Verifies that the actual Optional contains a value and
+        // gives this value to the given Consumer for further assertions.
+        assertThat(savedMember).hasValueSatisfying(member -> {
+            assertThat(member.getLoginId()).isEqualTo(newMember.getLoginId());
+            assertThat(member.getPassword()).isEqualTo(newMember.getPassword());
+            assertThat(member.getEmail()).isEqualTo(newMember.getEmail());
+            assertThat(member.getNickname()).isEqualTo(newMember.getNickname());
+            assertThat(member.getMemberType()).isEqualTo(newMember.getMemberType());
+        });
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원 번호 조회")
+    void findByUnregisteredMemberId() {
+        // 존재하지 않는 회원 번호(-1L)로 조회, 결과: Optional.empty()
+        Optional<Member> member = memberRepository.findByMemberId(-1L);
+
+        assertThat(member).isEmpty();
+    }
+
+    @Test
+    @DisplayName("로그인 아이디로 회원 조회")
+    void findByLoginId() {
+        // 회원 추가 후 로그인 아이디로 조회, 로그인 아이디 비교
+        Member newMember = new Member();
+        newMember.setLoginId("testId");
+
+        memberRepository.save(newMember);
+        Optional<Member> savedMember = memberRepository.findByMemberId(newMember.getMemberId());
+
+        assertThat(savedMember).hasValueSatisfying(member -> {
+            assertThat(member.getLoginId()).isEqualTo(newMember.getLoginId());
+        });
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 로그인 아이디로 회원 조회")
+    void findByUnregisteredLoginId() {
+        // 존재하지 않는 로그인 아이디로 회원 조회, 결과: Optional.empty()
+        Optional<Member> member = memberRepository.findByLoginId("unregisteredLoginId");
+
+        assertThat(member).isEmpty();
+    }
+
+    @Test
+    @DisplayName("이메일로 회원 조회")
+    void findByEmail() {
+        // 회원 추가 후 이메일로 조회, 이메일 비교
+        Member newMember = new Member();
+        newMember.setEmail("testEmail@gmail.com");
+
+        memberRepository.save(newMember);
+        Optional<Member> savedMember = memberRepository.findByMemberId(newMember.getMemberId());
+
+        assertThat(savedMember).hasValueSatisfying(member -> {
+            assertThat(member.getEmail()).isEqualTo(newMember.getEmail());
+        });
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이메일로 회원 조회")
+    void findByUnregisteredEmail() {
+        // 존재하지 않는 이메일로 회원 조회, 결과: Optional.empty()
+        Optional<Member> member = memberRepository.findByEmail("unregisteredEmail@gmail.com");
+
+        assertThat(member).isEmpty();
+    }
+
+    @Test
+    @DisplayName("닉네임으로 회원 조회")
+    void findByNickname() {
+        // 회원 추가 후 닉네임으로 조회, 닉네임 비교
+        Member newMember = new Member();
+        newMember.setNickname("testNickname");
+
+        memberRepository.save(newMember);
+        Optional<Member> savedMember = memberRepository.findByMemberId(newMember.getMemberId());
+
+        assertThat(savedMember).hasValueSatisfying(member -> {
+            assertThat(member.getNickname()).isEqualTo(newMember.getNickname());
+        });
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 닉네임으로 회원 조회")
+    void findByUnregisteredNickname() {
+        // 존재하지 않는 닉네임으로 회원 조회, 결과: Optional.empty()
+        Optional<Member> member = memberRepository.findByNickname("unregisteredNickname");
+
+        assertThat(member).isEmpty();
+    }
+
+    @Test
+    @DisplayName("회원 비밀번호 변경")
+    void updatePassword() {
+        // 회원 추가 후 비밀번호 변경, 조회된 회원 정보에 비밀번호 변경이 반영되었는지 검증
+        Member newMember = new Member();
+        newMember.setLoginId("testId");
+        newMember.setPassword("oldPassword");
+        newMember.setEmail("testEmail@gmail.com");
+        newMember.setNickname("testNickname");
+        newMember.setMemberType(MemberType.OWNER);
+        memberRepository.save(newMember);
+
+        String newPassword = "newPassword";
+        memberRepository.updatePassword(newMember.getMemberId(), newPassword);
+
+        Optional<Member> updatedMember = memberRepository.findByMemberId(newMember.getMemberId());
+        assertThat(updatedMember).hasValueSatisfying(member -> {
+            assertThat(member.getPassword()).isEqualTo(newPassword);
+        });
+    }
+
+    @Test
+    @DisplayName("회원 이메일 변경")
+    void updateEmail() {
+        // 회원 추가 후 이메일 변경, 조회된 회원 정보에 이메일 변경이 반영되었는지 검증
+        Member newMember = new Member();
+        newMember.setLoginId("testId");
+        newMember.setPassword("testPassword");
+        newMember.setEmail("oldEmail@gmail.com");
+        newMember.setNickname("testNickname");
+        newMember.setMemberType(MemberType.OWNER);
+        memberRepository.save(newMember);
+
+        String newEmail = "newEmail@gmail.com";
+        memberRepository.updateEmail(newMember.getMemberId(), newEmail);
+
+        Optional<Member> updatedMember = memberRepository.findByMemberId(newMember.getMemberId());
+        assertThat(updatedMember).hasValueSatisfying(member -> {
+            assertThat(member.getEmail()).isEqualTo(newEmail);
+        });
+    }
+
+    @Test
+    @DisplayName("회원 닉네임 변경")
+    void updateNickname() {
+        // 회원 추가 후 닉네임 변경, 조회된 회원 정보에 닉네임 변경이 반영되었는지 검증
+        Member newMember = new Member();
+        newMember.setLoginId("testId");
+        newMember.setPassword("testPassword");
+        newMember.setEmail("testEmail@gmail.com");
+        newMember.setNickname("oldNickname");
+        newMember.setMemberType(MemberType.OWNER);
+        memberRepository.save(newMember);
+
+        String newNickname = "newNickname";
+        memberRepository.updateNickname(newMember.getMemberId(), newNickname);
+
+        Optional<Member> updatedMember = memberRepository.findByMemberId(newMember.getMemberId());
+        assertThat(updatedMember).hasValueSatisfying(member -> {
+            assertThat(member.getNickname()).isEqualTo(newNickname);
+        });
+    }
+
+    @Test
+    @DisplayName("회원 삭제")
+    void deleteByMemberId() {
+        // 회원 추가 후 삭제, 삭제된 회원을 조회시 Optional.empty() 반환 검증
+        Member newMember = new Member();
+        newMember.setLoginId("testId");
+        newMember.setPassword("testPassword");
+        newMember.setEmail("testEmail@gmail.com");
+        newMember.setNickname("testNickname");
+        newMember.setMemberType(MemberType.OWNER);
+        memberRepository.save(newMember);
+
+        memberRepository.deleteByMemberId(newMember.getMemberId());
+        Optional<Member> deletedMember = memberRepository.findByMemberId(newMember.getMemberId());
+
+        assertThat(deletedMember).isEmpty();
+    }
+}

--- a/api/src/test/java/burgermap/repository/MySqlMenuCategoryRepositoryTest.java
+++ b/api/src/test/java/burgermap/repository/MySqlMenuCategoryRepositoryTest.java
@@ -1,0 +1,73 @@
+package burgermap.repository;
+
+import burgermap.entity.MenuCategory;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+class MySqlMenuCategoryRepositoryTest extends TestcontainersTest {
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private MenuCategoryRepository repository;
+
+    private final String[] menuCategoryNames = new String[] {
+            "버거", "감자튀김", "양파튀김", "피자", "치킨", "탄산음료", "맥주", "하이볼", "치즈스틱", "치즈볼"
+    };
+
+    @BeforeEach
+    void initMenuCategoryData() {
+        // 테스트를 위한 메뉴 카테고리 데이터 등록
+        // 테스트 케이스마다 Id 자동 생성 시작값 초기화
+        em.createNativeQuery("alter table menu_category AUTO_INCREMENT = 1").executeUpdate();
+        for (String menuCategoryName : menuCategoryNames) {
+            MenuCategory menuCategory = new MenuCategory();
+            menuCategory.setName(menuCategoryName);
+            em.persist(menuCategory);
+            System.out.println(menuCategory.getMenuCategoryId());
+        }
+    }
+
+    @Test
+    @DisplayName("등록된 모든 메뉴 카테고리 조회")
+    void findAll() {
+        // 등록된 모든 메뉴 카테고리 조회, 조회된 메뉴 카테고리 수와 메뉴 카테고리명 검증
+        List<MenuCategory> allMenuCategories = repository.findAll();
+
+        assertThat(allMenuCategories).hasSize(menuCategoryNames.length);
+        assertThat(allMenuCategories).extracting("name").contains(menuCategoryNames);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {1L, 5L, 10L})
+    @DisplayName("메뉴 카테고리 번호로 조회")
+    void findByMenuCategoryId(long menuCategoryId) {
+        // 메뉴 카테고리 번호로 조회, 조회된 메뉴 카테고리의 메뉴 카테고리명 검증
+        Optional<MenuCategory> menuCategory = repository.findByMenuCategoryId(menuCategoryId);
+        String MenuCategoryName = menuCategoryNames[(int) menuCategoryId - 1];
+
+        assertThat(menuCategory).hasValueSatisfying(category -> assertThat(category.getName()).isEqualTo(MenuCategoryName));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 메뉴 카테고리 번호로 조회")
+    void findByUnregisteredMenuCategoryId() {
+        // 존재하지 않는 메뉴 카테고리 번호(-1L, long 최댓값)로 조회, 결과: Optional.empty()
+        Optional<MenuCategory> menuCategoryNegativeId = repository.findByMenuCategoryId(-1L);
+        Optional<MenuCategory> menuCategoryUnregisteredId = repository.findByMenuCategoryId(Long.MAX_VALUE);
+
+        assertThat(menuCategoryNegativeId).isEmpty();
+        assertThat(menuCategoryUnregisteredId).isEmpty();
+    }
+}

--- a/api/src/test/java/burgermap/repository/MySqlStoreRepositoryTest.java
+++ b/api/src/test/java/burgermap/repository/MySqlStoreRepositoryTest.java
@@ -139,40 +139,6 @@ class MySqlStoreRepositoryTest extends TestcontainersTest {
     }
 
     @Test
-    @DisplayName("가게 정보 수정")
-    void updateStore() {
-        // 가게 등록 후 정보 수정, 조회된 가게 정보에 수정된 정보가 반영되었는지 검증
-        Member member = new Member();
-        member.setMemberType(MemberType.OWNER);
-        entityManager.persist(member);
-
-        Store oldStore = new Store();
-        oldStore.setMember(member);
-        oldStore.setName("oldStore");
-        oldStore.setPhone("010-1234-1111");
-        oldStore.setAddress("oldAddress");
-        oldStore.setIntroduction("oldIntroduction");
-        storeRepository.save(oldStore);
-
-        Store newStore = new Store();
-        newStore.setMember(member);
-        newStore.setName("newStore");
-        newStore.setPhone("010-1234-2222");
-        newStore.setAddress("newAddress");
-        newStore.setIntroduction("newIntroduction");
-        storeRepository.updateStore(oldStore.getStoreId(), newStore);
-
-        Optional<Store> updatedStore = storeRepository.findByStoreId(oldStore.getStoreId());
-
-        assertThat(updatedStore).hasValueSatisfying(store -> {
-            assertThat(store.getName()).isEqualTo(newStore.getName());
-            assertThat(store.getPhone()).isEqualTo(newStore.getPhone());
-            assertThat(store.getAddress()).isEqualTo(newStore.getAddress());
-            assertThat(store.getIntroduction()).isEqualTo(newStore.getIntroduction());
-        });
-    }
-
-    @Test
     @DisplayName("가게 삭제")
     void deleteByStoreId() {
         // 가게 등록 후 삭제, 삭제된 가게 정보가 조회시 Optional.empty() 반환 검증

--- a/api/src/test/java/burgermap/repository/MySqlStoreRepositoryTest.java
+++ b/api/src/test/java/burgermap/repository/MySqlStoreRepositoryTest.java
@@ -1,0 +1,196 @@
+package burgermap.repository;
+
+import burgermap.entity.Member;
+import burgermap.entity.Store;
+import burgermap.enums.MemberType;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+class MySqlStoreRepositoryTest extends TestcontainersTest {
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("가게 추가 및 가게 번호 조회")
+    void saveAndFindByStoreId() {
+        // 가게 추가 후 조회, 저장한 정보와 조회된 정보가 같은지 검증
+        Member member = new Member();
+        member.setMemberType(MemberType.OWNER);
+        entityManager.persist(member);
+
+        Store newStore = new Store();
+        newStore.setMember(member);
+        newStore.setName("testStore");
+        newStore.setPhone("010-1234-5678");
+        newStore.setAddress("testAddress");
+        newStore.setIntroduction("testIntroduction");
+
+        storeRepository.save(newStore);
+        Optional<Store> savedStore = storeRepository.findByStoreId(newStore.getStoreId());
+
+        assertThat(savedStore).hasValueSatisfying(store -> {
+            assertThat(store.getMember().getMemberId()).isEqualTo(member.getMemberId());
+            assertThat(store.getName()).isEqualTo(newStore.getName());
+            assertThat(store.getPhone()).isEqualTo(newStore.getPhone());
+            assertThat(store.getAddress()).isEqualTo(newStore.getAddress());
+            assertThat(store.getIntroduction()).isEqualTo(newStore.getIntroduction());
+        });
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 가게 번호 조회")
+    void findByUnregisteredStoreId() {
+        // 존재하지 않는 가게 번호(-1L)로 조회, 결과: Optional.empty()
+        Member member = new Member();
+        member.setMemberType(MemberType.OWNER);
+        entityManager.persist(member);
+
+        Store newStore = new Store();
+        newStore.setMember(member);
+        newStore.setName("testStore");
+        newStore.setPhone("010-1234-5678");
+        newStore.setAddress("testAddress");
+        newStore.setIntroduction("testIntroduction");
+        storeRepository.save(newStore);
+
+        Optional<Store> store = storeRepository.findByStoreId(-1L);
+
+        assertThat(store).isEmpty();
+    }
+
+    @Test
+    @DisplayName("가게를 소유한 회원 번호로 가게 조회")
+    void findByMemberId() {
+        // 가게 정보에 포함된 회원의 번호로 가게 조회
+        Member member = new Member();
+        member.setMemberType(MemberType.OWNER);
+        entityManager.persist(member);
+
+        Store newStore1 = new Store();
+        newStore1.setMember(member);
+        newStore1.setName("testStore1");
+        newStore1.setPhone("010-1234-1111");
+        newStore1.setAddress("testAddress1");
+        newStore1.setIntroduction("testIntroduction1");
+
+        Store newStore2 = new Store();
+        newStore2.setMember(member);
+        newStore2.setName("testStore2");
+        newStore2.setPhone("010-1234-2222");
+        newStore2.setAddress("testAddress2");
+        newStore2.setIntroduction("testIntroduction2");
+
+        storeRepository.save(newStore1);
+        storeRepository.save(newStore2);
+        List<Store> stores = storeRepository.findByMemberId(member.getMemberId());
+
+        assertThat(stores).hasSize(2);
+        // Extract the values of the given field or property from the Iterable's elements
+        // under test into a new Iterable, this new Iterable becoming the Iterable under test.
+        assertThat(stores).extracting("name")
+                .containsExactly(newStore1.getName(), newStore2.getName());
+        assertThat(stores).extracting("phone")
+                .containsExactly(newStore1.getPhone(), newStore2.getPhone());
+        assertThat(stores).extracting("address")
+                .containsExactly(newStore1.getAddress(), newStore2.getAddress());
+        assertThat(stores).extracting("introduction")
+                .containsExactly(newStore1.getIntroduction(), newStore2.getIntroduction());
+    }
+
+    @Test
+    @DisplayName("가게를 소유하지 않은 회원 번호로 가게 조회")
+    void findByNotOwnerMemberId() {
+        // 가게를 등록하지 않은 회원 번호(-1L)로 가게 조회, 결과: empty list
+        Member member = new Member();
+        member.setMemberType(MemberType.OWNER);
+        entityManager.persist(member);
+
+        Store newStore1 = new Store();
+        newStore1.setMember(member);
+        newStore1.setName("testStore1");
+        newStore1.setPhone("010-1234-1111");
+        newStore1.setAddress("testAddress1");
+        newStore1.setIntroduction("testIntroduction1");
+
+        Store newStore2 = new Store();
+        newStore1.setMember(member);
+        newStore1.setName("testStore2");
+        newStore1.setPhone("010-1234-2222");
+        newStore1.setAddress("testAddress2");
+        newStore1.setIntroduction("testIntroduction2");
+
+        storeRepository.save(newStore1);
+        storeRepository.save(newStore2);
+
+        List<Store> stores = storeRepository.findByMemberId(-1L);
+
+        assertThat(stores).isEmpty();
+    }
+
+    @Test
+    @DisplayName("가게 정보 수정")
+    void updateStore() {
+        // 가게 등록 후 정보 수정, 조회된 가게 정보에 수정된 정보가 반영되었는지 검증
+        Member member = new Member();
+        member.setMemberType(MemberType.OWNER);
+        entityManager.persist(member);
+
+        Store oldStore = new Store();
+        oldStore.setMember(member);
+        oldStore.setName("oldStore");
+        oldStore.setPhone("010-1234-1111");
+        oldStore.setAddress("oldAddress");
+        oldStore.setIntroduction("oldIntroduction");
+        storeRepository.save(oldStore);
+
+        Store newStore = new Store();
+        newStore.setMember(member);
+        newStore.setName("newStore");
+        newStore.setPhone("010-1234-2222");
+        newStore.setAddress("newAddress");
+        newStore.setIntroduction("newIntroduction");
+        storeRepository.updateStore(oldStore.getStoreId(), newStore);
+
+        Optional<Store> updatedStore = storeRepository.findByStoreId(oldStore.getStoreId());
+
+        assertThat(updatedStore).hasValueSatisfying(store -> {
+            assertThat(store.getName()).isEqualTo(newStore.getName());
+            assertThat(store.getPhone()).isEqualTo(newStore.getPhone());
+            assertThat(store.getAddress()).isEqualTo(newStore.getAddress());
+            assertThat(store.getIntroduction()).isEqualTo(newStore.getIntroduction());
+        });
+    }
+
+    @Test
+    @DisplayName("가게 삭제")
+    void deleteByStoreId() {
+        // 가게 등록 후 삭제, 삭제된 가게 정보가 조회시 Optional.empty() 반환 검증
+        Member member = new Member();
+        member.setMemberType(MemberType.OWNER);
+        entityManager.persist(member);
+
+        Store newStore = new Store();
+        newStore.setMember(member);
+        newStore.setName("testStore");
+        newStore.setPhone("010-1234-5678");
+        newStore.setAddress("testAddress");
+        newStore.setIntroduction("testIntroduction");
+
+        storeRepository.save(newStore);
+        storeRepository.deleteByStoreId(newStore.getStoreId());
+
+        Optional<Store> store = storeRepository.findByStoreId(newStore.getStoreId());
+        assertThat(store).isEmpty();
+    }
+}

--- a/api/src/test/java/burgermap/repository/TestcontainersTest.java
+++ b/api/src/test/java/burgermap/repository/TestcontainersTest.java
@@ -4,8 +4,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -15,28 +13,11 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 @Transactional
 class TestcontainersTest {
-//    @Container
-//    private static MySQLContainer container = new MySQLContainer("mysql:8.3.0")
-//            .withDatabaseName("burgermap-test")
-//            .withUsername("user")
-//            .withPassword("useruser");
-
     @Container
     private MySQLContainer container = new MySQLContainer("mysql:8.3.0")
             .withDatabaseName("burgermap-test")
             .withUsername("user")
             .withPassword("useruser");
-
-//    @DynamicPropertySource  // 동적으로 프로퍼티 설정
-//    static void dynamicProperties(DynamicPropertyRegistry registry) {
-//        registry.add("spring.datasource.url", container::getJdbcUrl);
-//        registry.add("spring.datasource.username", container::getUsername);
-//        registry.add("spring.datasource.password", container::getPassword);
-//        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
-//        registry.add("spring.jpa.properties.hibernate.hbm2ddl.import_files", () -> "init.sql");
-//        registry.add("logging.level.org.hibernate.SQL", () -> "DEBUG");
-//        registry.add("logging.level.org.hibernate.orm.jdbc.bind", () -> "TRACE");
-//    }
 
     @Test
     @DisplayName("MySQL 컨테이너 동작")

--- a/api/src/test/java/burgermap/repository/TestcontainersTest.java
+++ b/api/src/test/java/burgermap/repository/TestcontainersTest.java
@@ -29,7 +29,7 @@ class TestcontainersTest {
         registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
         registry.add("spring.jpa.properties.hibernate.hbm2ddl.import_files", () -> "init.sql");
         registry.add("logging.level.org.hibernate.SQL", () -> "DEBUG");
-        registry.add("logging.level.org.hibernate.orm.dbc.bind", () -> "TRACE");
+        registry.add("logging.level.org.hibernate.orm.jdbc.bind", () -> "TRACE");
     }
 
     @Test

--- a/api/src/test/java/burgermap/repository/TestcontainersTest.java
+++ b/api/src/test/java/burgermap/repository/TestcontainersTest.java
@@ -15,22 +15,28 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 @Transactional
 class TestcontainersTest {
+//    @Container
+//    private static MySQLContainer container = new MySQLContainer("mysql:8.3.0")
+//            .withDatabaseName("burgermap-test")
+//            .withUsername("user")
+//            .withPassword("useruser");
+
     @Container
-    private static MySQLContainer container = new MySQLContainer("mysql:8.3.0")
+    private MySQLContainer container = new MySQLContainer("mysql:8.3.0")
             .withDatabaseName("burgermap-test")
             .withUsername("user")
             .withPassword("useruser");
 
-    @DynamicPropertySource  // 동적으로 프로퍼티 설정
-    static void dynamicProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", container::getJdbcUrl);
-        registry.add("spring.datasource.username", container::getUsername);
-        registry.add("spring.datasource.password", container::getPassword);
-        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
-        registry.add("spring.jpa.properties.hibernate.hbm2ddl.import_files", () -> "init.sql");
-        registry.add("logging.level.org.hibernate.SQL", () -> "DEBUG");
-        registry.add("logging.level.org.hibernate.orm.jdbc.bind", () -> "TRACE");
-    }
+//    @DynamicPropertySource  // 동적으로 프로퍼티 설정
+//    static void dynamicProperties(DynamicPropertyRegistry registry) {
+//        registry.add("spring.datasource.url", container::getJdbcUrl);
+//        registry.add("spring.datasource.username", container::getUsername);
+//        registry.add("spring.datasource.password", container::getPassword);
+//        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
+//        registry.add("spring.jpa.properties.hibernate.hbm2ddl.import_files", () -> "init.sql");
+//        registry.add("logging.level.org.hibernate.SQL", () -> "DEBUG");
+//        registry.add("logging.level.org.hibernate.orm.jdbc.bind", () -> "TRACE");
+//    }
 
     @Test
     @DisplayName("MySQL 컨테이너 동작")

--- a/api/src/test/java/burgermap/repository/TestcontainersTest.java
+++ b/api/src/test/java/burgermap/repository/TestcontainersTest.java
@@ -1,0 +1,40 @@
+package burgermap.repository;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+@Transactional
+class TestcontainersTest {
+    @Container
+    private static MySQLContainer container = new MySQLContainer("mysql:8.3.0")
+            .withDatabaseName("burgermap-test")
+            .withUsername("user")
+            .withPassword("useruser");
+
+    @DynamicPropertySource  // 동적으로 프로퍼티 설정
+    static void dynamicProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", container::getJdbcUrl);
+        registry.add("spring.datasource.username", container::getUsername);
+        registry.add("spring.datasource.password", container::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
+        registry.add("spring.jpa.properties.hibernate.hbm2ddl.import_files", () -> "init.sql");
+        registry.add("logging.level.org.hibernate.SQL", () -> "DEBUG");
+        registry.add("logging.level.org.hibernate.orm.dbc.bind", () -> "TRACE");
+    }
+
+    @Test
+    @DisplayName("MySQL 컨테이너 동작")
+    void containerTest() {
+        Assertions.assertThat(container.isRunning()).isTrue();
+    }
+}

--- a/api/src/test/java/burgermap/service/MemberServiceTest.java
+++ b/api/src/test/java/burgermap/service/MemberServiceTest.java
@@ -2,6 +2,7 @@ package burgermap.service;
 
 import burgermap.entity.Member;
 import burgermap.enums.MemberType;
+import burgermap.exception.store.NotOwnerMemberException;
 import burgermap.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -253,5 +254,34 @@ class MemberServiceTest {
         Member deletedMember = memberService.deleteMember(memberId);
 
         assertThat(deletedMember).isEqualTo(member);
+    }
+
+    @Test
+    @DisplayName("회원 타입이 Owner인지 확인 - Owner인 경우")
+    void isMemberTypeOwner() {
+        // 레포에서 회원 번호로 회원 조회 후 타입 확인 -> Owner인 경우 예외가 발생하지 않음을 검증
+        Long memberId = 1L;
+        Member member = new Member();
+        member.setMemberId(memberId);
+        member.setMemberType(MemberType.OWNER);
+
+        Mockito.when(memberRepository.findByMemberId(memberId)).thenReturn(Optional.of(member));
+
+        assertThatCode(() -> memberService.isMemberTypeOwner(memberId)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("회원 타입이 Owner인지 확인 - Owner가 아닌 경우")
+    void isNotMemberTypeOwner() {
+        // 레포에서 회원 번호로 회원 조회 후 타입 확인 -> Owner가 아닌 경우 NotOwnerMemberException 발생 검증
+        Long memberId = 1L;
+        Member member = new Member();
+        member.setMemberId(memberId);
+        member.setMemberType(MemberType.CUSTOMER);
+
+        Mockito.when(memberRepository.findByMemberId(memberId)).thenReturn(Optional.of(member));
+
+        assertThatThrownBy(() -> memberService.isMemberTypeOwner(memberId))
+                .isInstanceOf(NotOwnerMemberException.class);
     }
 }

--- a/api/src/test/java/burgermap/service/MemberServiceTest.java
+++ b/api/src/test/java/burgermap/service/MemberServiceTest.java
@@ -192,10 +192,7 @@ class MemberServiceTest {
         member.setPassword("oldPassword");
         String newPassword = "newPassword";
 
-        Mockito.when(memberRepository.updatePassword(memberId, newPassword)).then(invocation -> {
-            member.setPassword(newPassword);
-            return Optional.of(member);
-        });
+        Mockito.when(memberRepository.findByMemberId(memberId)).thenReturn(Optional.of(member));
         Member result = memberService.changePassword(memberId, newPassword);
 
         assertThat(result.getPassword()).isEqualTo(newPassword);
@@ -212,10 +209,7 @@ class MemberServiceTest {
         member.setEmail("old@gmail.com");
         String newEmail = "new@gmail.com";
 
-        Mockito.when(memberRepository.updateEmail(memberId, newEmail)).then(invocation -> {
-            member.setEmail(newEmail);
-            return Optional.of(member);
-        });
+        Mockito.when(memberRepository.findByMemberId(memberId)).thenReturn(Optional.of(member));
         Member result = memberService.changeEmail(memberId, newEmail);
 
         assertThat(result.getEmail()).isEqualTo(newEmail);
@@ -232,10 +226,7 @@ class MemberServiceTest {
         member.setNickname("oldNickname");
         String newNickname = "newNickname";
 
-        Mockito.when(memberRepository.updateNickname(memberId, newNickname)).then(invocation -> {
-            member.setNickname(newNickname);
-            return Optional.of(member);
-        });
+        Mockito.when(memberRepository.findByMemberId(memberId)).thenReturn(Optional.of(member));
         Member result = memberService.changeNickname(memberId, newNickname);
 
         assertThat(result.getNickname()).isEqualTo(newNickname);

--- a/api/src/test/java/burgermap/service/MemberServiceTest.java
+++ b/api/src/test/java/burgermap/service/MemberServiceTest.java
@@ -1,0 +1,257 @@
+package burgermap.service;
+
+import burgermap.entity.Member;
+import burgermap.enums.MemberType;
+import burgermap.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @InjectMocks
+    MemberService memberService;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("회원 추가")
+    void addMember() {
+        // Member 객체를 레포지터리에 전달, 레포지터리에서 저장하며 Id 부여 -> Id 부여 확인
+        Member newMember = new Member();
+        newMember.setLoginId("testId");
+        newMember.setPassword("testPw");
+        newMember.setEmail("testId@gmail.com");
+        newMember.setNickname("testNickname");
+        newMember.setMemberType(MemberType.OWNER);
+
+        Mockito.when(memberRepository.save(newMember)).thenAnswer(invocation ->
+        {
+            newMember.setMemberId(1L);
+            return newMember;
+        });
+
+        memberService.addMember(newMember);
+
+        assertThat(newMember.getMemberId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("아이디 중복 확인 - 아이디가 중복되는 경우")
+    void checkDuplicatedId() {
+        // 아이디 중복되는 경우 레포지터리는 아이디를 가진 회원 객체(Optional<Member>) 반환
+        // 서비스는 Optional.isPresent() 반환 -> true 반환 검증
+        String duplicatedId = "duplicatedId";
+
+        Mockito.when(memberRepository.findByLoginId(duplicatedId)).thenReturn(Optional.of(new Member()));
+        boolean result = memberService.checkIdDuplication(duplicatedId);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("아이디 중복 확인 - 아이디가 중복되지 않는 경우")
+    void checkNotDuplicatedId() {
+        // 아이디 중복되지 않는 경우 레포지터리는 Optional.ofNullable(null) == Optional.empty() 반환
+        // 서비스는 Optional.isPresent() 반환 -> false 반환 검증
+        String notDuplicatedId = "notDuplicatedId";
+
+        Mockito.when(memberRepository.findByLoginId(notDuplicatedId)).thenReturn(Optional.empty());
+        boolean result = memberService.checkIdDuplication(notDuplicatedId);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("이메일 중복 확인 - 이메일이 중복되는 경우")
+    void checkDuplicatedEmail() {
+        String duplicatedEmail = "duplicatedEmail";
+
+        Mockito.when(memberRepository.findByEmail(duplicatedEmail)).thenReturn(Optional.of(new Member()));
+        boolean result = memberService.checkEmailDuplication(duplicatedEmail);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("이메일 중복 확인 - 이메일이 중복되지 않는 경우")
+    void checkNotDuplicatedEmail() {
+        String notDuplicatedEmail = "notDuplicatedEmail";
+
+        Mockito.when(memberRepository.findByEmail(notDuplicatedEmail)).thenReturn(Optional.empty());
+        boolean result = memberService.checkEmailDuplication(notDuplicatedEmail);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 확인 - 닉네임이 중복되는 경우")
+    void checkDuplicatedNickname() {
+        String duplicatedNickname = "duplicatedNickname";
+
+        Mockito.when(memberRepository.findByNickname(duplicatedNickname)).thenReturn(Optional.of(new Member()));
+        boolean result = memberService.checkNicknameDuplication(duplicatedNickname);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 확인 - 닉네임이 중복되지 않는 경우")
+    void checkNotDuplicatedNickname() {
+        String notDuplicatedNickname = "notDuplicatedNickname";
+
+        Mockito.when(memberRepository.findByNickname(notDuplicatedNickname)).thenReturn(Optional.empty());
+        boolean result = memberService.checkNicknameDuplication(notDuplicatedNickname);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("로그인 - 로그인 성공")
+    void loginSuccess() {
+        // 주어진 아이디를 가진 회원 조회 후 비밀번호 비교, 일치하면 회원 객체 반환 -> 반환된 회원 객체 검증
+        String loginId = "testId";
+        String password = "testPw";
+
+        Member member = new Member();
+        member.setLoginId(loginId);
+        member.setPassword(password);
+
+        Mockito.when(memberRepository.findByLoginId(loginId)).thenReturn(Optional.of(member));
+        Member result = memberService.login(loginId, password);
+
+        assertThat(result).isEqualTo(member);
+    }
+
+    @Test
+    @DisplayName("로그인 - 로그인 실패 / 주어진 아이디를 가진 회원이 존재하지 않는 경우")
+    void loginFailUnregisteredLoginId() {
+        // 주어진 아이디를 가진 회원이 없다면 레포에서 Optional.empty() 반환 -> null 반환 검증
+        String unregisteredLoginId = "unregisteredTestId";
+        String password = "testPw";
+
+        Mockito.when(memberRepository.findByLoginId(unregisteredLoginId)).thenReturn(Optional.empty());
+        Member result = memberService.login(unregisteredLoginId, password);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("로그인 - 로그인 실패 / 비밀번호가 일치하지 않는 경우")
+    void loginFailInvalidPassword() {
+        // 주어진 아이디를 가진 회원 조회 후 비밀번호 비교 비밀번호가 일치하지 않는 경우 null 반환 -> 반환값 null 검증
+        String loginId = "testId";
+        String validPassword = "testPw";
+
+        Member member = new Member();
+        member.setLoginId(loginId);
+        member.setPassword(validPassword);
+
+        String invalidPassword = "invalidTestPw";
+
+        Mockito.when(memberRepository.findByLoginId(loginId)).thenReturn(Optional.of(member));
+        Member result = memberService.login(loginId, invalidPassword);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("내 정보 조회")
+    void getMyInfo() {
+        // 로그인한 회원 자신의 정보 조회 -> 회원 객체 반환 검증
+        // 로그인 검증이 선행되므로 회원 조회는 반드시 성공한다고 가정.
+        Long memberId = 1L;
+        Member member = new Member();
+        member.setMemberId(memberId);
+
+        Mockito.when(memberRepository.findByMemberId(memberId)).thenReturn(Optional.of(member));
+        Member result = memberService.getMyInfo(memberId);
+
+        assertThat(result).isEqualTo(member);
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경")
+    void changePassword() {
+        // 레포에서 회원번호로 회원 조회 후 비밀번호 변경 -> 비밀번호 변경 여부 검증
+        // 로그인 검증이 선행되므로 회원 조회는 반드시 성공한다고 가정.
+        Long memberId = 1L;
+        Member member = new Member();
+        member.setMemberId(memberId);
+        member.setPassword("oldPassword");
+        String newPassword = "newPassword";
+
+        Mockito.when(memberRepository.updatePassword(memberId, newPassword)).then(invocation -> {
+            member.setPassword(newPassword);
+            return Optional.of(member);
+        });
+        Member result = memberService.changePassword(memberId, newPassword);
+
+        assertThat(result.getPassword()).isEqualTo(newPassword);
+    }
+
+    @Test
+    @DisplayName("이메일 변경")
+    void changeEmail() {
+        // 레포에서 회원번호로 회원 조회 후 이메일 변경 -> 이메일 변경 여부 검증
+        // 로그인 검증이 선행되므로 회원 조회는 반드시 성공한다고 가정.
+        Long memberId = 1L;
+        Member member = new Member();
+        member.setMemberId(memberId);
+        member.setEmail("old@gmail.com");
+        String newEmail = "new@gmail.com";
+
+        Mockito.when(memberRepository.updateEmail(memberId, newEmail)).then(invocation -> {
+            member.setEmail(newEmail);
+            return Optional.of(member);
+        });
+        Member result = memberService.changeEmail(memberId, newEmail);
+
+        assertThat(result.getEmail()).isEqualTo(newEmail);
+    }
+
+    @Test
+    @DisplayName("닉네임 변경")
+    void changeNickname() {
+        // 레포에서 회원번호로 회원 조회 후 닉네임 변경 -> 닉네임 변경 여부 검증
+        // 로그인 검증이 선행되므로 회원 조회는 반드시 성공한다고 가정.
+        Long memberId = 1L;
+        Member member = new Member();
+        member.setMemberId(memberId);
+        member.setNickname("oldNickname");
+        String newNickname = "newNickname";
+
+        Mockito.when(memberRepository.updateNickname(memberId, newNickname)).then(invocation -> {
+            member.setNickname(newNickname);
+            return Optional.of(member);
+        });
+        Member result = memberService.changeNickname(memberId, newNickname);
+
+        assertThat(result.getNickname()).isEqualTo(newNickname);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴")
+    void deleteMember() {
+        // 레포에서 회원 번호로 회원 조회 후 제거, 조회된 회원 객체 반환 -> 회원 객체 반환 검증
+        // 로그인 검증이 선행되므로 회원 조회는 반드시 성공한다고 가정.
+        Long memberId = 1L;
+        Member member = new Member();
+        member.setMemberId(memberId);
+
+        Mockito.when(memberRepository.deleteByMemberId(memberId)).thenReturn(Optional.of(member));
+        Member deletedMember = memberService.deleteMember(memberId);
+
+        assertThat(deletedMember).isEqualTo(member);
+    }
+}

--- a/api/src/test/resources/application.properties
+++ b/api/src/test/resources/application.properties
@@ -3,7 +3,6 @@ spring.datasource.username=user
 spring.datasource.password=useruser
 
 spring.jpa.hibernate.ddl-auto=create
-spring.jpa.properties.hibernate.hbm2ddl.import_files=init.sql
 
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.orm.jdbc.bind=TRACE

--- a/api/src/test/resources/application.properties
+++ b/api/src/test/resources/application.properties
@@ -1,0 +1,9 @@
+spring.datasource.url=jdbc:tc:mysql:8.3.0:///burgermap-test
+spring.datasource.username=user
+spring.datasource.password=useruser
+
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.properties.hibernate.hbm2ddl.import_files=init.sql
+
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.orm.jdbc.bind=TRACE


### PR DESCRIPTION
# 목표
* 엔티티의 레포지터리를 DB 레포지터리로 변경
* 테스트 코드 작성 (testcontainers 활용)
* 네이버 클라우드에 배포

## 엔티티의 레포지터리를 DB 레포지터리로 변경
* 회원, 가게 엔티티의 레포지터리를 HashMap에서 MySQL+JPA(SpringDataJPA) 레포지터리로 변경했습니다.
* 회원, 가게, 음식 엔티티의 속성 중 다른 엔티티와의 관계 표현을 위해 삽입한 식별 번호를 해당 엔티티 객체로 변경했습니다.
   ```java
   @Entity
   public class Store {
      @Id
      @GeneratedValue(strategy = GenerationType.IDENTITY)
      private Long storeId;
      @ManyToOne
      private Member member;  // Long memberId 에서 엔티티 객체로 변경
   ```
  * 컨트롤러에서 DTO를 엔티티로 변경하는 과정에서 연관된 다른 엔티티 객체 필드는 null로 둔 채 서비스 레이어로 전달, 서비스 레이어에서 엔티티 객체를 채우도록 변경했습니다.
    * 컨트롤러에서 해당 엔티티의 레포지터리까지 참조하기보다는 이미 레포지터리를 참조하고있는 서비스 계층에서 몰아서 처리하는게 더 깔끔하다고 생각됩니다.

## 테스트 코드 작성 (testcontainers 활용)
* 회원, 가게 레포지터리에 대한 테스트 코드를 작성했습니다.
* 이전처럼 Testcontainers 컨테이너 생성 과정을 포함하는 슈퍼클래스를 테스트 클래스에서 상속받는 형식으로 구성했는데 컨테이너를 static 필드로 선언하는 경우 첫 자식 클래스의 테스트 이후 두번째 자식 클래스부터는 컨테이너가 동작하지 않아 인스턴스 필드로 변경했습니다.
  * 원인은 아직 못찾았습니다.
* 가게 레포지터리 테스트에서 가게 엔티티가 회원 엔티티와 다대일 관계가 있어 EntityManager를 이용해 회원을 추가하는 방식으로 진행했습니다. TestEntityManager 등을 찾았으나 Testcontainer 슈퍼클래스를 이용하는 현재 구조에서 @DataJpaTest를 적용하는 시도가 실패해 EntityManager를 사용했습니다.

## 배포
* 주중에 크레딧을 신청해 아직 승인이 되지 않았습니다.🙇

# TODO
* 이어서 테스트 코드 작성
* 네이버 클라우드에 배포
* Optional 사용 관련 정리
  * "Optional.orElse"와 "throw"가 별개로 작성된 부분을 "Optional.orElseThrow"로 정리
  * 레포지터리 레이어에서 수행할 작업이 서비스 레이어에 포함되어 Optional이 애매하게 사용되는 부분 정리
    * ex) 가게 삭제: 서비스 레이어에서 가게 존재 여부 확인, 레포지터리에서 가게 조회시에 "Optional.get" 사용하여 삭제된 가게 정보 반환 -> 레포지터리에서 "Optional.orElseThrow"로 존재 여부 확인까지 수행하도록 정리
* 서비스간의 순환참조가 일어나지 않도록 참조 관계 다시 고려해보기