### PR TITLE
[#20] 레포지터리 레이어에 포함된 엔티티 업데이트 메서드를 서비스 레이어로 이동

### DIFF
--- a/api/src/main/java/burgermap/repository/HashMapMemberRepository.java
+++ b/api/src/main/java/burgermap/repository/HashMapMemberRepository.java
@@ -48,36 +48,6 @@ public class HashMapMemberRepository implements MemberRepository{
     }
 
     @Override
-    public Optional<Member> updatePassword(Long memberId, String newPassword) {
-        Member member = repository.get(memberId);
-        if (member == null) {
-            return Optional.empty();
-        }
-        member.setPassword(newPassword);
-        return Optional.of(member);
-    }
-
-    @Override
-    public Optional<Member> updateEmail(Long memberId, String newEmail) {
-        Member member = repository.get(memberId);
-        if (member == null) {
-            return Optional.empty();
-        }
-        member.setEmail(newEmail);
-        return Optional.of(member);
-    }
-
-    @Override
-    public Optional<Member> updateNickname(Long memberId, String newNickname) {
-        Member member = repository.get(memberId);
-        if (member == null) {
-            return Optional.empty();
-        }
-        member.setNickname(newNickname);
-        return Optional.of(member);
-    }
-
-    @Override
     public Optional<Member> deleteByMemberId(Long memberId) {
         return Optional.ofNullable(repository.remove(memberId));
     }

--- a/api/src/main/java/burgermap/repository/HashMapStoreRepository.java
+++ b/api/src/main/java/burgermap/repository/HashMapStoreRepository.java
@@ -37,18 +37,6 @@ public class HashMapStoreRepository implements StoreRepository{
     }
 
     @Override
-    public Optional<Store> updateStore(Long storeId, Store newStore) {
-        Store oldStore = repository.get(storeId);
-        if (oldStore == null) {
-            return Optional.empty();
-        }
-
-        newStore.setStoreId(storeId);
-        repository.put(storeId, newStore);
-        return Optional.of(newStore);
-    }
-
-    @Override
     public Optional<Store> deleteByStoreId(Long storeId) {
         Store store = repository.remove(storeId);
         return Optional.ofNullable(store);

--- a/api/src/main/java/burgermap/repository/MemberRepository.java
+++ b/api/src/main/java/burgermap/repository/MemberRepository.java
@@ -10,8 +10,5 @@ public interface MemberRepository {
     public Optional<Member> findByLoginId(String loginId);
     public Optional<Member> findByEmail(String email);
     public Optional<Member> findByNickname(String nickname);
-    public Optional<Member> updatePassword(Long memberId, String newPassword);
-    public Optional<Member> updateEmail(Long memberId, String newEmail);
-    public Optional<Member> updateNickname(Long memberId, String newNickname);
     public Optional<Member> deleteByMemberId(Long memberId);
 }

--- a/api/src/main/java/burgermap/repository/MySqlMemberRepository.java
+++ b/api/src/main/java/burgermap/repository/MySqlMemberRepository.java
@@ -39,27 +39,6 @@ public class MySqlMemberRepository implements MemberRepository {
     }
 
     @Override
-    public Optional<Member> updatePassword(Long memberId, String newPassword) {
-        Member member = repository.findById(memberId).orElseThrow();
-        member.setPassword(newPassword);
-        return Optional.of(member);
-    }
-
-    @Override
-    public Optional<Member> updateEmail(Long memberId, String newEmail) {
-        Member member = repository.findById(memberId).orElseThrow();
-        member.setEmail(newEmail);
-        return Optional.of(member);
-    }
-
-    @Override
-    public Optional<Member> updateNickname(Long memberId, String newNickname) {
-        Member member = repository.findById(memberId).orElseThrow();
-        member.setNickname(newNickname);
-        return Optional.of(member);
-    }
-
-    @Override
     public Optional<Member> deleteByMemberId(Long memberId) {
         Member member = repository.findById(memberId).orElseThrow();
         repository.deleteById(memberId);

--- a/api/src/main/java/burgermap/repository/MySqlStoreRepository.java
+++ b/api/src/main/java/burgermap/repository/MySqlStoreRepository.java
@@ -30,13 +30,6 @@ public class MySqlStoreRepository implements StoreRepository {
     }
 
     @Override
-    public Optional<Store> updateStore(Long storeId, Store newStore) {
-        newStore.setStoreId(storeId);
-        repository.save(newStore);
-        return Optional.of(newStore);
-    }
-
-    @Override
     public Optional<Store> deleteByStoreId(Long storeId) {
         Store store = repository.findById(storeId).get();
         repository.delete(store);

--- a/api/src/main/java/burgermap/repository/StoreRepository.java
+++ b/api/src/main/java/burgermap/repository/StoreRepository.java
@@ -9,6 +9,5 @@ public interface StoreRepository {
     public Store save(Store store);
     public Optional<Store> findByStoreId(Long storeId);
     public List<Store> findByMemberId(Long memberId);
-    public Optional<Store> updateStore(Long storeId, Store newStore);
     public Optional<Store> deleteByStoreId(Long storeId);
 }

--- a/api/src/main/java/burgermap/service/MemberService.java
+++ b/api/src/main/java/burgermap/service/MemberService.java
@@ -66,21 +66,25 @@ public class MemberService {
     }
 
     public Member changePassword(Long memberId, String newPassword) {
-        Optional<Member> member = repository.updatePassword(memberId, newPassword);
-        log.debug("member password changed: {}", member.get());
-        return member.get();
+        // 로그인이 필요하므로 회원 조회 결과가 존재
+        Member member = repository.findByMemberId(memberId).get();
+        member.setPassword(newPassword);
+        log.debug("member password changed: {}", member);
+        return member;
     }
 
     public Member changeEmail(Long memberId, String newEmail) {
-        Optional<Member> member = repository.updateEmail(memberId, newEmail);
-        log.debug("member email changed: {}", member.get());
-        return member.get();
+        Member member = repository.findByMemberId(memberId).get();
+        member.setEmail(newEmail);
+        log.debug("member email changed: {}", member);
+        return member;
     }
 
     public Member changeNickname(Long memberId, String newNickname) {
-        Optional<Member> member = repository.updateNickname(memberId, newNickname);
-        log.debug("member nickname changed: {}", member.get());
-        return member.get();
+        Member member = repository.findByMemberId(memberId).get();
+        member.setNickname(newNickname);
+        log.debug("member nickname changed: {}", member);
+        return member;
     }
 
     public Member deleteMember(Long memberId) {

--- a/api/src/main/java/burgermap/service/StoreService.java
+++ b/api/src/main/java/burgermap/service/StoreService.java
@@ -46,11 +46,14 @@ public class StoreService {
 
     public Store updateStore(Long requestMemberId, Long storeId, Store newStoreInfo) {
         memberService.isMemberTypeOwner(requestMemberId);
-        Store oldStore = checkStoreExistence(storeId);
-        checkStoreBelongTo(oldStore, requestMemberId);
-        newStoreInfo.setMember(memberRepository.findByMemberId(requestMemberId).orElseThrow());
-        Optional<Store> newStore = storeRepository.updateStore(storeId, newStoreInfo);
-        return newStore.orElse(null);
+        Store store = checkStoreExistence(storeId);
+        checkStoreBelongTo(store, requestMemberId);
+
+        store.setName(newStoreInfo.getName());
+        store.setAddress(newStoreInfo.getAddress());
+        store.setPhone(newStoreInfo.getPhone());
+        store.setIntroduction(newStoreInfo.getIntroduction());
+        return store;
     }
 
     public Store deleteStore(Long requestMemberId, Long storeId) {

--- a/api/src/test/java/burgermap/repository/MySqlMemberRepositoryTest.java
+++ b/api/src/test/java/burgermap/repository/MySqlMemberRepositoryTest.java
@@ -123,69 +123,6 @@ class MySqlMemberRepositoryTest extends TestcontainersTest{
     }
 
     @Test
-    @DisplayName("회원 비밀번호 변경")
-    void updatePassword() {
-        // 회원 추가 후 비밀번호 변경, 조회된 회원 정보에 비밀번호 변경이 반영되었는지 검증
-        Member newMember = new Member();
-        newMember.setLoginId("testId");
-        newMember.setPassword("oldPassword");
-        newMember.setEmail("testEmail@gmail.com");
-        newMember.setNickname("testNickname");
-        newMember.setMemberType(MemberType.OWNER);
-        memberRepository.save(newMember);
-
-        String newPassword = "newPassword";
-        memberRepository.updatePassword(newMember.getMemberId(), newPassword);
-
-        Optional<Member> updatedMember = memberRepository.findByMemberId(newMember.getMemberId());
-        assertThat(updatedMember).hasValueSatisfying(member -> {
-            assertThat(member.getPassword()).isEqualTo(newPassword);
-        });
-    }
-
-    @Test
-    @DisplayName("회원 이메일 변경")
-    void updateEmail() {
-        // 회원 추가 후 이메일 변경, 조회된 회원 정보에 이메일 변경이 반영되었는지 검증
-        Member newMember = new Member();
-        newMember.setLoginId("testId");
-        newMember.setPassword("testPassword");
-        newMember.setEmail("oldEmail@gmail.com");
-        newMember.setNickname("testNickname");
-        newMember.setMemberType(MemberType.OWNER);
-        memberRepository.save(newMember);
-
-        String newEmail = "newEmail@gmail.com";
-        memberRepository.updateEmail(newMember.getMemberId(), newEmail);
-
-        Optional<Member> updatedMember = memberRepository.findByMemberId(newMember.getMemberId());
-        assertThat(updatedMember).hasValueSatisfying(member -> {
-            assertThat(member.getEmail()).isEqualTo(newEmail);
-        });
-    }
-
-    @Test
-    @DisplayName("회원 닉네임 변경")
-    void updateNickname() {
-        // 회원 추가 후 닉네임 변경, 조회된 회원 정보에 닉네임 변경이 반영되었는지 검증
-        Member newMember = new Member();
-        newMember.setLoginId("testId");
-        newMember.setPassword("testPassword");
-        newMember.setEmail("testEmail@gmail.com");
-        newMember.setNickname("oldNickname");
-        newMember.setMemberType(MemberType.OWNER);
-        memberRepository.save(newMember);
-
-        String newNickname = "newNickname";
-        memberRepository.updateNickname(newMember.getMemberId(), newNickname);
-
-        Optional<Member> updatedMember = memberRepository.findByMemberId(newMember.getMemberId());
-        assertThat(updatedMember).hasValueSatisfying(member -> {
-            assertThat(member.getNickname()).isEqualTo(newNickname);
-        });
-    }
-
-    @Test
     @DisplayName("회원 삭제")
     void deleteByMemberId() {
         // 회원 추가 후 삭제, 삭제된 회원을 조회시 Optional.empty() 반환 검증

--- a/api/src/test/java/burgermap/repository/MySqlStoreRepositoryTest.java
+++ b/api/src/test/java/burgermap/repository/MySqlStoreRepositoryTest.java
@@ -139,40 +139,6 @@ class MySqlStoreRepositoryTest extends TestcontainersTest {
     }
 
     @Test
-    @DisplayName("가게 정보 수정")
-    void updateStore() {
-        // 가게 등록 후 정보 수정, 조회된 가게 정보에 수정된 정보가 반영되었는지 검증
-        Member member = new Member();
-        member.setMemberType(MemberType.OWNER);
-        entityManager.persist(member);
-
-        Store oldStore = new Store();
-        oldStore.setMember(member);
-        oldStore.setName("oldStore");
-        oldStore.setPhone("010-1234-1111");
-        oldStore.setAddress("oldAddress");
-        oldStore.setIntroduction("oldIntroduction");
-        storeRepository.save(oldStore);
-
-        Store newStore = new Store();
-        newStore.setMember(member);
-        newStore.setName("newStore");
-        newStore.setPhone("010-1234-2222");
-        newStore.setAddress("newAddress");
-        newStore.setIntroduction("newIntroduction");
-        storeRepository.updateStore(oldStore.getStoreId(), newStore);
-
-        Optional<Store> updatedStore = storeRepository.findByStoreId(oldStore.getStoreId());
-
-        assertThat(updatedStore).hasValueSatisfying(store -> {
-            assertThat(store.getName()).isEqualTo(newStore.getName());
-            assertThat(store.getPhone()).isEqualTo(newStore.getPhone());
-            assertThat(store.getAddress()).isEqualTo(newStore.getAddress());
-            assertThat(store.getIntroduction()).isEqualTo(newStore.getIntroduction());
-        });
-    }
-
-    @Test
     @DisplayName("가게 삭제")
     void deleteByStoreId() {
         // 가게 등록 후 삭제, 삭제된 가게 정보가 조회시 Optional.empty() 반환 검증


### PR DESCRIPTION
## 10/06 멘토링 - 엔티티 업데이트 메서드는 서비스 레이어에

엔티티를 수정하는 작업은 데이터를 수정한다는 관점에서 레포지터리 레이어에 포함시켰으나 서비스 레이어에 포함되는 것이 더 잘 어울림
* 엔티티의 수정은 단순히 데이터 변경만으로 이루어지는 작업이 아님. 새로운 값 검증 등의 서비스 로직이 포함되며 엔티티의 수정은 모든 서비스 로직을 거쳐 그 결과를 반영하는 작업으로 서비스 로직에 포함됨.
* 레포지터리의 역할은 엔티티를 수정하는 것이 아니라 서비스 로직을 통해 변경된 엔티티의 정보를 DB에 반영하는 것.
  * 어플리케이션단에서의 수정은 서비스 관할, DB단에서의 수정은 레포지터리 관할
* 서비스 로직을 통해 결정되는 엔티티 수정 작업과 단순 수정 내용의 반영 작업을 서비스 레이어와 레포지터리 레이어로 명확히 분리.

## 수정 내역
* 회원 레포지터리, 가게 레포지터리의 정보 수정 메서드를 제거, 각 엔티티의 서비스 레이어에 구현
* 회원 레포지터리, 가게 레포지터리의 테스트 코드에서 제거된 메서드의 테스트 제거

현재 17 브랜치에서 추가한 서비스 레이어 코드는 20 브랜치 분기 이후 작성되어 아직 레포지터리의 엔티티 업데이트 메서드를 참조해 테스트가 실패합니다.